### PR TITLE
Add packet-loss and Docker-notes

### DIFF
--- a/testing_from_home.md
+++ b/testing_from_home.md
@@ -67,6 +67,8 @@ In case you want to block *everything*, change the rule to let the simulator(s) 
     ```
     sudo iptables -A INPUT -p tcp --dport 15657 -j ACCEPT
     sudo iptables -A INPUT -p tcp --sport 15657 -j ACCEPT
+    sudo iptables -A OUTPUT -p tcp --dport 15657 -j ACCEPT
+    sudo iptables -A OUTPUT -p tcp --sport 15657 -j ACCEPT
     # +more for other simulator ports you use
     sudo iptables -A INPUT -j DROP
     sudo iptables -A OUTPUT -j DROP


### PR DESCRIPTION
- When disconnected from the network you should not be able to send packets
- Docker notes are helpful if you want to test it yourself, since it is not obvious that you need the capability or that docker-compose is unsuitable

~Note that the proposed command for turning on network-sending loss _will_ crash current `network_rust`-users here:~
https://github.com/TTK4145/network-rust/blob/711059088905305a5c70b523e85f3cfa885e2d7b/src/udpnet/peers.rs#L31

~With this error: `{ code: 1, kind: PermissionDenied, message: "Operation not permitted" }`, which is not that much different from the current issue when unplugging the ethernet-cable~
Update: now resolved with release `v0.2.0` of `network-rust`